### PR TITLE
exit code should be 1 if child proc of forego crashes and burns

### DIFF
--- a/start.go
+++ b/start.go
@@ -172,6 +172,11 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 			if flagRestart {
 				f.startProcess(idx, procNum, proc, env, of)
 				return
+			} else {
+				stderr, err = ps.StderrPipe()
+				if err != nil {
+					os.Exit(1) // ?
+				}
 			}
 
 		case <-f.teardown.Barrier():

--- a/start.go
+++ b/start.go
@@ -173,7 +173,6 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 				f.startProcess(idx, procNum, proc, env, of)
 				return
 			} else {
-				stderr, err = ps.StderrPipe()
 				if !ps.ProcessState.Success() {
 					os.Exit(1) // ?
 				}

--- a/start.go
+++ b/start.go
@@ -174,7 +174,7 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 				return
 			} else {
 				stderr, err = ps.StderrPipe()
-				if err != nil {
+				if !ps.ProcessState.Success() {
 					os.Exit(1) // ?
 				}
 			}


### PR DESCRIPTION
-> not 0 so that systemd can restart it

This is what happens when you try and boot it up with redis being SHUTDOWN prior. Before this tweak you'd have EXIT CODE: 0 at the bottom.

``` java
ukens-MacBook-Pro-2:banshee uken$ ../forego/forego start; echo "EXIT CODE: ${PIPESTATUS[0]}"
forego | starting web.1 on port 5000
web.1  | New Relic for Node.js was unable to bootstrap itself due to an error:
web.1  | Error: New Relic for Node.js requires a version of Node equal to or
web.1  | greater than 0.6.0. Not starting!
web.1  |     at Object.<anonymous> (/Users/uken/code/banshee/node_modules/newrelic/index.js:18:11)
web.1  |     at Module._compile (module.js:398:26)
web.1  |     at Object.Module._extensions..js (module.js:405:10)
web.1  |     at Module.load (module.js:344:32)
web.1  |     at Function.Module._load (module.js:301:12)
web.1  |     at Module.require (module.js:354:17)
web.1  |     at require (internal/module.js:12:17)
web.1  |     at Object.<anonymous> (/Users/uken/code/banshee/banshee.coffee:4:3)
web.1  |     at Object.<anonymous> (/Users/uken/code/banshee/banshee.coffee:129:4)
web.1  |     at Module._compile (module.js:398:26)
web.1  | info: socket.io started
web.1  | REDIS at localhost:6379
web.1  | Listening on 5000
web.1  | events.js:141
web.1  |       throw er; // Unhandled 'error' event
web.1  |       ^
web.1  |
web.1  | Error: Redis connection to localhost:6379 failed - connect ECONNREFUSED 127.0.0.1:6379
web.1  |     at RedisKeyspace.RedisClient.on_error (/Users/uken/code/banshee/node_modules/redis/index.js:196:24)
web.1  |     at Socket.<anonymous> (/Users/uken/code/banshee/node_modules/redis/index.js:106:14)
web.1  |     at emitOne (events.js:77:13)
web.1  |     at Socket.emit (events.js:169:7)
web.1  |     at emitErrorNT (net.js:1256:8)
web.1  |     at nextTickCallbackWith2Args (node.js:455:9)
web.1  |     at process._tickCallback (node.js:369:17)
EXIT CODE: 1
```
